### PR TITLE
Fix: Allow colors to be updated dynamically

### DIFF
--- a/src/RemixIcon.tsx
+++ b/src/RemixIcon.tsx
@@ -36,7 +36,7 @@ const RemixIcon = ({
     () => ({
       fill: typeof color === 'string' ? color : color.value,
     }),
-    [],
+    [color],
     createAnimatedPropAdapter(
       (props) => {
         if (Object.keys(props).includes('fill')) {


### PR DESCRIPTION
### Issue: If color is updated in state, or changed via hot reload, the color stays as what it was initially.

Example: 
```
<RemixIcon name="account-box-fill" color="black"/>
```

This will initially render black as expected. But if we then change it from "black" to "white", the component does not rerender. In expo, you have to restart the app in order to see the change. Adding the color to the dependency array fixes this and automatically updates the color as it changes. 